### PR TITLE
Cleanup Based on Initial Tests

### DIFF
--- a/lib/tasks/model_transporter.rake
+++ b/lib/tasks/model_transporter.rake
@@ -34,11 +34,17 @@ namespace :model_transport do
 
     puts "Loading data from #{source_db_desc[:database]} at #{source_db_desc[:host]} into #{target_db_desc[:database]} at #{target_db_desc[:host]}" if debug
 
+    start_time = Time.now
+    puts "Starting transport at #{start_time.to_s}."
+
     result = Transporter::Result.new
     records.each do |record|
       puts "Transporting #{record.class.to_s} #{record.id}..." if debug
       record.transport(target_db_desc, result)
     end
+
+    end_time = Time.now
+    puts "Completed transport at #{end_time.to_s} (duration: #{(end_time - start_time).to_i} seconds)."
 
     puts "RESULTS:\n=====\n"
     puts result.created_records.to_json

--- a/lib/tasks/model_transporter.rake
+++ b/lib/tasks/model_transporter.rake
@@ -8,7 +8,7 @@ namespace :model_transport do
 
   desc 'pulls data in from an external source (e.g. staging)'
   task :load_from => :environment do |t, args|
-    extracted_records_file = ENV['EXTRACTED_RECORDS_FILE']
+    transported_records_file = ENV['TRANSPORTED_RECORDS_FILE']
     debug = TRUE_BOOLEAN_VALUES.include?(ENV['DEBUG'])
     source_db_adapter  = ENV['SOURCE_DB_ADAPTER'] || 'mysql2'
     source_db_name     = ENV['SOURCE_DB_NAME']
@@ -25,22 +25,23 @@ namespace :model_transport do
       password: source_db_password
     }
     target_db_desc = ActiveRecord::Base.connection_config
+    Transporter::ActiveRecordExtension.debug = debug
 
-    prev_extracted_records = Transporter::Utils.load_json_file(extracted_records_file)
+    prev_transported_records = Transporter::Utils.load_json_file(transported_records_file)
     ActiveRecord::Base.establish_connection(source_db_desc)
-    records = Transporter.config.records_to_extract(prev_extracted_records)
+    records = Transporter.config.records_to_transport(prev_transported_records)
     raise "No records found to etract." unless records
 
     puts "Loading data from #{source_db_desc[:database]} at #{source_db_desc[:host]} into #{target_db_desc[:database]} at #{target_db_desc[:host]}" if debug
 
-    transported_records = {}
+    result = Transporter::Result.new
     records.each do |record|
       puts "Transporting #{record.class.to_s} #{record.id}..." if debug
-      Transporter::Utils.deep_merge!(transported_records, record.transport(target_db_desc))
+      record.transport(target_db_desc, result)
     end
 
     puts "RESULTS:\n=====\n"
-    puts transported_records.to_json
+    puts result.created_records.to_json
     puts "====="
   end
 

--- a/lib/transporter/config.rb
+++ b/lib/transporter/config.rb
@@ -1,21 +1,31 @@
 module Transporter
   class Config
-    attr_reader :records_to_extract, :foo
+    attr_reader :records_to_transport, :transport_scope
 
     def initialize
-      @records_to_extract = nil
+      @records_to_transport = nil
+      @transport_scope = {}
     end
 
-    def configure_records_to_extract(&block)
-      @records_to_extract = block
+    def configure_records_to_transport(&block)
+      @records_to_transport = block
     end
 
-    def records_to_extract(prev_extracted_records)
-      unless @records_to_extract.present?
+    def records_to_transport(prev_transported_records)
+      unless @records_to_transport.present?
         raise "No proc defined for extracting records to be transported. Please configure this as port of the environment initialization."
       end
 
-      records = @records_to_extract.call(prev_extracted_records)
+      @records_to_transport.call(@transport_scope, prev_transported_records)
+
+      records = @transport_scope.collect do |klass, ids|
+        klass.where(id: ids)
+      end
+      records.flatten
+    end
+
+    def scope_for(klass)
+      @transport_scope[klass]
     end
   end
 end

--- a/lib/transporter/config.rb
+++ b/lib/transporter/config.rb
@@ -1,10 +1,14 @@
+require 'transporter/scope'
+
 module Transporter
   class Config
-    attr_reader :records_to_transport, :transport_scope
+    attr_accessor :max_association_count
+    attr_reader :records_to_transport, :scope
 
     def initialize
+      @max_association_count = 25
       @records_to_transport = nil
-      @transport_scope = {}
+      @scope = Scope.new
     end
 
     def configure_records_to_transport(&block)
@@ -16,16 +20,9 @@ module Transporter
         raise "No proc defined for extracting records to be transported. Please configure this as port of the environment initialization."
       end
 
-      @records_to_transport.call(@transport_scope, prev_transported_records)
+      @records_to_transport.call(@scope, prev_transported_records)
 
-      records = @transport_scope.collect do |klass, ids|
-        klass.where(id: ids)
-      end
-      records.flatten
-    end
-
-    def scope_for(klass)
-      @transport_scope[klass]
+      records = @scope.seed_records
     end
   end
 end

--- a/lib/transporter/result.rb
+++ b/lib/transporter/result.rb
@@ -1,0 +1,38 @@
+module Transporter
+  class Result
+    attr_reader :pending_records, :created_records
+
+    def initialize
+      @pending_records = {}
+      @created_records = {}
+    end
+
+    def add_pending_record(klass, id)
+      @pending_records[klass.to_s] ||= []
+      @pending_records[klass.to_s] << id
+    end
+
+    def remove_pending_record(klass, id)
+      @pending_records[klass.to_s] ||= []
+      @pending_records[klass.to_s].delete(id)
+    end
+
+    def add_created_record(klass, id)
+      @created_records[klass.to_s] ||= []
+      @created_records[klass.to_s] << id
+      remove_pending_record(klass, id)
+    end
+
+    def contains?(klass, id)
+      pending_records_for_class = @pending_records[klass.to_s] || []
+      return true if pending_records_for_class.include?(id)
+      
+      created_records_for_class = @created_records[klass.to_s] || []
+      return true if created_records_for_class.include?(id)
+
+      raise "ID Collision: ID #{id} for #{klass.to_s} already exists but was not apart of this transport." if klass.exists?(id)
+
+      return false
+    end
+  end
+end

--- a/lib/transporter/scope.rb
+++ b/lib/transporter/scope.rb
@@ -1,0 +1,38 @@
+module Transporter
+  class Scope
+    attr_reader :scoped_classes
+
+    CONFIG_KEYS = [ :ids, :associations ]
+
+    def initialize
+      @scoped_classes = {}
+    end
+
+    def configure_class(klass, scope_config)
+      @scoped_classes[klass] = scope_config.keep_if { |k,v| CONFIG_KEYS.include?(k) }
+    end
+
+    def seed_records
+      seed_records = []
+
+      @scoped_classes.each do |klass, config|
+        next unless config[:ids]
+        seed_records << klass.where(id: config[:ids]).compact
+      end
+      
+      return seed_records.flatten
+    end
+
+    def records_for(klass)
+      scope_config = @scoped_classes[klass]
+      return nil unless scope_config
+      return scope_config[:ids]
+    end
+
+    def associations_for(klass)
+      scope_config = @scoped_classes[klass]
+      return nil unless scope_config
+      return scope_config[:associations]
+    end
+  end
+end

--- a/lib/transporter/utils.rb
+++ b/lib/transporter/utils.rb
@@ -9,7 +9,7 @@ module Transporter
     end
 
     def self.load_json_file(file_path)
-      return unless File.exists?(file_path)
+      return if file_path.nil? || !File.exists?(file_path)
 
       JSON.parse(File.read(file_path))
     end


### PR DESCRIPTION
Based on my initial testing, I addressed the following cleanup items:

* Updates all naming conventions to use 'transport' as the primary verb instead of 'extract'.
* Updates the structure of the transported records file in light of the fact that IDs must match in the source and target DBs.
* Adds an explanation of the transport scoping functionality to the README.
* Adds debug logging support to the ActiveRecord extension.
* Adds a result accumulation object instead of merging the results of each step of the traversal.
* Updates record copying logic to handle initialization callbacks (uses  instead of ).
* Ensures the DB connection for all classes is always reverted to the source DB to ensure valid association and record lookups.
* Updates tranversal logic to respect scope constraints and prevent pulling in the entire dataset.